### PR TITLE
chore: Output commit hash after successful commit

### DIFF
--- a/src/commit_ai_command.sh
+++ b/src/commit_ai_command.sh
@@ -115,4 +115,7 @@ else
     }
 fi
 
+commit_hash=$(git rev-parse HEAD)
+
 echo "✅ Done"
+echo "🔗 Commit hash: $commit_hash"


### PR DESCRIPTION
### Summary
This update enhances the developer experience by displaying the unique identifier (hash) of the newly created commit immediately after the automated commit process finishes. This provides clear, actionable feedback, making it easier for team members to reference or link to the specific change right away.

### Technical Changes
*   **Modified Component:** The script `src/commit_ai_command.sh` was updated.
*   **Logic Alteration:** Added a command to capture and display the commit hash.
    *   A new line `commit_hash=$(git rev-parse HEAD)` was added to execute the `git rev-parse` command, which retrieves the hash of the current HEAD (the commit just created).
    *   A subsequent `echo` statement, `echo "🔗 Commit hash: $commit_hash"`, was added to print this hash to the standard output with a clear label.
*   **Output Enhancement:** The final script output now provides two lines of confirmation: the existing "✅ Done" message, followed by the new "🔗 Commit hash: [hash]" message.

### Commit Messages Reference
*   `d61a225` - chore: output commit hash after successful commit